### PR TITLE
Added: Ability to specify target directory in CLI for compress/decompress

### DIFF
--- a/src/cli/src/commands/compress.rs
+++ b/src/cli/src/commands/compress.rs
@@ -1,28 +1,84 @@
 use crate::macros::AbortableResult;
 use prs_rs::{comp::prs_compress_unsafe, util::prs_calculate_max_compressed_size};
 use rayon::prelude::*;
-use std::fs::{read, remove_file, write};
+use std::fs::{create_dir_all, read, remove_file, write};
 use std::path::Path;
 use walkdir::WalkDir;
 
-pub(crate) fn compress_files(path: &str) {
-    let path = Path::new(path);
-    if path.is_dir() {
-        WalkDir::new(path)
-            .into_iter()
-            .filter_map(Result::ok)
-            .filter(|e| e.file_type().is_file())
-            .par_bridge()
-            .for_each(|entry| {
-                let input_path = entry.path();
-                compress_file(
-                    input_path,
-                    format!("{}.prs", input_path.to_string_lossy()).as_ref(),
-                );
-            });
-    } else {
-        compress_file(path, format!("{}.prs", path.to_string_lossy()).as_ref());
+pub(crate) fn compress_files(source: &str, target: Option<&str>) {
+    let source_path = Path::new(source);
+
+    match target {
+        Some(target_str) => {
+            let target_path = Path::new(target_str);
+            if source_path.is_dir() {
+                compress_directory_to_target(source_path, target_path);
+            } else {
+                compress_file_to_target(source_path, target_path);
+            }
+        }
+        None => {
+            // In-place mode: write next to source and delete original
+            if source_path.is_dir() {
+                WalkDir::new(source_path)
+                    .into_iter()
+                    .filter_map(Result::ok)
+                    .filter(|e| e.file_type().is_file())
+                    .par_bridge()
+                    .for_each(|entry| {
+                        let input_path = entry.path();
+                        let output_path = format!("{}.prs", input_path.to_string_lossy());
+                        compress_file_inplace(input_path, output_path.as_ref());
+                    });
+            } else {
+                let output_path = format!("{}.prs", source_path.to_string_lossy());
+                compress_file_inplace(source_path, output_path.as_ref());
+            }
+        }
     }
+}
+
+fn compress_directory_to_target(source_dir: &Path, target_dir: &Path) {
+    WalkDir::new(source_dir)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_file())
+        .par_bridge()
+        .for_each(|entry| {
+            let input_path = entry.path();
+            // Compute relative path from source directory
+            let relative_path = input_path.strip_prefix(source_dir).unwrap();
+            // Build output path: target_dir + relative_path + .prs
+            let mut output_path = target_dir.join(relative_path);
+            let new_filename = format!(
+                "{}.prs",
+                output_path.file_name().unwrap().to_string_lossy()
+            );
+            output_path.set_file_name(new_filename);
+
+            // Ensure parent directory exists for recursive structures
+            if let Some(parent) = output_path.parent() {
+                create_dir_all(parent).unwrap_abort();
+            }
+
+            compress_file(input_path, &output_path);
+        });
+}
+
+fn compress_file_to_target(source_file: &Path, target: &Path) {
+    let output_path = if target.is_dir() {
+        // Target is a directory, use source filename with .prs extension
+        let filename = format!(
+            "{}.prs",
+            source_file.file_name().unwrap().to_string_lossy()
+        );
+        target.join(filename)
+    } else {
+        // Target is a file path, use as-is
+        target.to_path_buf()
+    };
+
+    compress_file(source_file, &output_path);
 }
 
 fn compress_file(input_path: &Path, output_path: &Path) {
@@ -40,5 +96,9 @@ fn compress_file(input_path: &Path, output_path: &Path) {
     let compressed_data = unsafe { compressed_data.assume_init() };
     let compressed_slice = &compressed_data[0..compressed_size];
     write(output_path, compressed_slice).unwrap_abort();
+}
+
+fn compress_file_inplace(input_path: &Path, output_path: &Path) {
+    compress_file(input_path, output_path);
     remove_file(input_path).unwrap_abort();
 }

--- a/src/cli/src/commands/decompress.rs
+++ b/src/cli/src/commands/decompress.rs
@@ -1,37 +1,97 @@
 use crate::macros::AbortableResult;
 use prs_rs::decomp::{prs_calculate_decompressed_size, prs_decompress_unsafe};
 use rayon::prelude::*;
-use std::fs::{read, remove_file, write};
+use std::fs::{create_dir_all, read, remove_file, write};
 use std::path::Path;
 use walkdir::WalkDir;
 
-pub(crate) fn decompress_files(path: &str) {
-    let path = Path::new(path);
-    if path.is_dir() {
-        WalkDir::new(path)
-            .into_iter()
-            .filter_map(Result::ok)
-            .filter(|e| {
-                e.file_type().is_file()
-                    && e.path()
-                        .extension()
-                        .is_some_and(|ext| ext.eq_ignore_ascii_case("prs"))
-            })
-            .par_bridge()
-            .for_each(|entry| {
-                let input_path = entry.path();
-                let path_str = input_path.to_str().unwrap();
+pub(crate) fn decompress_files(source: &str, target: Option<&str>) {
+    let source_path = Path::new(source);
+
+    match target {
+        Some(target_str) => {
+            let target_path = Path::new(target_str);
+            if source_path.is_dir() {
+                decompress_directory_to_target(source_path, target_path);
+            } else if source_path
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("prs"))
+            {
+                decompress_file_to_target(source_path, target_path);
+            }
+        }
+        None => {
+            // In-place mode: write next to source (without .prs) and delete original
+            if source_path.is_dir() {
+                WalkDir::new(source_path)
+                    .into_iter()
+                    .filter_map(Result::ok)
+                    .filter(|e| {
+                        e.file_type().is_file()
+                            && e.path()
+                                .extension()
+                                .is_some_and(|ext| ext.eq_ignore_ascii_case("prs"))
+                    })
+                    .par_bridge()
+                    .for_each(|entry| {
+                        let input_path = entry.path();
+                        let path_str = input_path.to_str().unwrap();
+                        let output_path = &path_str[..path_str.len() - 4];
+                        decompress_file_inplace(input_path, output_path.as_ref());
+                    });
+            } else if source_path
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("prs"))
+            {
+                let path_str = source_path.to_str().unwrap();
                 let output_path = &path_str[..path_str.len() - 4];
-                decompress_file(input_path, output_path.as_ref());
-            });
-    } else if path
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("prs"))
-    {
-        let path_str = path.to_str().unwrap();
-        let output_path = &path_str[..path_str.len() - 4];
-        decompress_file(path, output_path.as_ref());
+                decompress_file_inplace(source_path, output_path.as_ref());
+            }
+        }
     }
+}
+
+fn decompress_directory_to_target(source_dir: &Path, target_dir: &Path) {
+    WalkDir::new(source_dir)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_type().is_file()
+                && e.path()
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("prs"))
+        })
+        .par_bridge()
+        .for_each(|entry| {
+            let input_path = entry.path();
+            // Compute relative path from source directory
+            let relative_path = input_path.strip_prefix(source_dir).unwrap();
+            // Build output path: target_dir + relative_path (without .prs extension)
+            let output_path = target_dir.join(relative_path);
+            // Remove the .prs extension
+            let output_str = output_path.to_string_lossy();
+            let output_path: &Path = output_str[..output_str.len() - 4].as_ref();
+
+            // Ensure parent directory exists
+            if let Some(parent) = output_path.parent() {
+                create_dir_all(parent).unwrap_abort();
+            }
+
+            decompress_file(input_path, output_path);
+        });
+}
+
+fn decompress_file_to_target(source_file: &Path, target: &Path) {
+    let output_path = if target.is_dir() {
+        // Target is a directory, use source filename without .prs extension
+        let filename = source_file.file_stem().unwrap();
+        target.join(filename)
+    } else {
+        // Target is a file path, use as-is
+        target.to_path_buf()
+    };
+
+    decompress_file(source_file, &output_path);
 }
 
 fn decompress_file(input_path: &Path, output_path: &Path) {
@@ -42,5 +102,9 @@ fn decompress_file(input_path: &Path, output_path: &Path) {
     unsafe { prs_decompress_unsafe(compressed_data.as_ptr(), decomp.as_mut_ptr() as *mut u8) };
     let decomp = unsafe { decomp.assume_init() };
     write(output_path, decomp).unwrap_abort();
+}
+
+fn decompress_file_inplace(input_path: &Path, output_path: &Path) {
+    decompress_file(input_path, output_path);
     remove_file(input_path).unwrap_abort();
 }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -19,10 +19,10 @@ fn main() {
 
     match toplevel.nested {
         Commands::Compress(cmd) => {
-            compress_files(&cmd.source);
+            compress_files(&cmd.source, cmd.target.as_deref());
         }
         Commands::Decompress(cmd) => {
-            decompress_files(&cmd.source);
+            decompress_files(&cmd.source, cmd.target.as_deref());
         }
         Commands::Test(cmd) => {
             test_compression(&cmd.source);

--- a/src/cli/src/options.rs
+++ b/src/cli/src/options.rs
@@ -23,6 +23,10 @@ pub(crate) struct CompressCommand {
     /// path to the file to compress, or directory of files to compress
     #[argh(option)]
     pub(crate) source: String,
+
+    /// output path for compressed file(s). If omitted, outputs next to source with .prs extension and deletes original
+    #[argh(option)]
+    pub(crate) target: Option<String>,
 }
 
 /// Decompresses all PRS files in the given directory.
@@ -32,6 +36,10 @@ pub(crate) struct DecompressCommand {
     /// path to the file to decompress, or directory of files to decompress
     #[argh(option)]
     pub(crate) source: String,
+
+    /// output path for decompressed file(s). If omitted, outputs next to source without .prs extension and deletes original
+    #[argh(option)]
+    pub(crate) target: Option<String>,
 }
 
 /// Tests that the compressor round trips, by compressing, calculating size and decompressing.


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/prs-rs/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Compress and decompress commands now accept optional target paths to specify custom output locations
* Added support for directory-wide compression and decompression operations with flexible destination handling
* Improved file routing to correctly handle both file and directory targets

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->